### PR TITLE
feat: Add comprehensive pagination support for event queries and fix …

### DIFF
--- a/src/tests/idn.rs
+++ b/src/tests/idn.rs
@@ -19,15 +19,17 @@
 //! and the indexing of subscription_id, pulse_round, and beacon_public_key events.
 
 use crate::shared::*;
-use crate::substrate::*;
-use crate::tests::{ChainKey, ChainTrees};
 use crate::websockets::*;
-use crate::*;
-
-use hex_literal::hex;
-use serde::{Deserialize, Serialize};
+use crate::{open_trees, Indexer, SubstrateKey, SubscriptionId, Bytes32, IndexError};
+use crate::tests::{ChainKey, ChainTrees};
+use std::str::FromStr;
+use std::time::Duration;
+use sled::Config;
 use subxt::{events::EventDetails, utils::AccountId32, PolkadotConfig};
 use tokio::sync::mpsc;
+use zerocopy::{AsBytes, FromBytes};
+use serde::{Deserialize, Serialize};
+use hex_literal::hex;
 
 // This struct mocks the EventDetails from subxt to test our macros
 #[derive(Debug, Clone)]
@@ -532,4 +534,422 @@ async fn test_ideal_network_indexer_process_event() {
     assert_eq!(variant_40_0.len(), 1);
     assert_eq!(variant_41_0.len(), 1);
     assert_eq!(variant_41_1.len(), 1);
+}
+
+// ==========================================
+// SUBSCRIPTION ID KEY CONSISTENCY TESTS
+// ==========================================
+// These tests verify that the subscription ID storage and retrieval bug is fixed
+
+#[tokio::test]
+async fn test_subscription_id_key_consistency() {
+    // Test subscription ID from the user's example - without 0x prefix
+    let test_hex = "c589244f4d5c8e64c378acde541600e215464ec7292e475225e92b0f32896f1b";
+    
+    // Create subscription ID from hex
+    let subscription_id = SubscriptionId::from_str(test_hex).expect("Failed to parse subscription ID");
+    
+    // Verify the subscription ID was created correctly
+    assert_eq!(subscription_id.0.0, hex!("c589244f4d5c8e64c378acde541600e215464ec7292e475225e92b0f32896f1b"));
+    
+    println!("✓ Subscription ID created correctly from hex string without 0x prefix");
+}
+
+#[tokio::test]
+async fn test_subscription_id_key_consistency_with_0x_prefix() {
+    // Test subscription ID with 0x prefix - this is what frontend might send
+    let test_hex = "0xc589244f4d5c8e64c378acde541600e215464ec7292e475225e92b0f32896f1b";
+    
+    // Create subscription ID from hex with 0x prefix
+    let subscription_id = SubscriptionId::from_str(test_hex).expect("Failed to parse subscription ID with 0x prefix");
+    
+    // Verify the subscription ID was created correctly (same as without prefix)
+    assert_eq!(subscription_id.0.0, hex!("c589244f4d5c8e64c378acde541600e215464ec7292e475225e92b0f32896f1b"));
+    
+    // Test that both versions create identical subscription IDs
+    let without_prefix = SubscriptionId::from_str("c589244f4d5c8e64c378acde541600e215464ec7292e475225e92b0f32896f1b").unwrap();
+    assert_eq!(subscription_id, without_prefix);
+    
+    println!("✓ Subscription ID created correctly from hex string with 0x prefix");
+    println!("✓ Both 0x and non-0x formats produce identical results");
+}
+
+#[tokio::test]
+async fn test_subscription_id_database_storage_retrieval() {
+    // Create a temporary database
+    let db = sled::Config::new().temporary(true).open().expect("Failed to open database");
+    let subscription_tree = db.open_tree(b"subscription_id").expect("Failed to open tree");
+    
+    // Test data
+    let subscription_id = SubscriptionId::from(hex!("c589244f4d5c8e64c378acde541600e215464ec7292e475225e92b0f32896f1b"));
+    let block_number = 12345u32;
+    let event_index = 67u16;
+    
+    // Simulate how the key is stored during event processing
+    let storage_key = Bytes32Key {
+        key: subscription_id.0.0, // This is what the storage logic uses
+        block_number: block_number.into(),
+        event_index: event_index.into(),
+    };
+    
+    // Store the key in the database
+    subscription_tree.insert(storage_key.as_bytes(), &[]).expect("Failed to insert");
+    
+    // Simulate how the key is retrieved during event lookup
+    let retrieval_key = subscription_id.0; // This is what the retrieval logic uses (Bytes32)
+    
+    // Check if we can find events with this key
+    let mut found_events = Vec::new();
+    let mut iter = subscription_tree.scan_prefix(&retrieval_key.0).keys();
+    
+    while let Some(Ok(key)) = iter.next_back() {
+        let key_struct = Bytes32Key::read_from(&key).unwrap();
+        found_events.push(Event {
+            block_number: key_struct.block_number.into(),
+            event_index: key_struct.event_index.into(),
+        });
+        
+        if found_events.len() >= 100 {
+            break;
+        }
+    }
+    
+    // Verify we found the event we stored
+    assert_eq!(found_events.len(), 1, "Should find exactly one event");
+    assert_eq!(found_events[0].block_number, block_number);
+    assert_eq!(found_events[0].event_index, event_index);
+    
+    println!("✓ Database storage and retrieval work correctly");
+    println!("  - Stored key using: subscription_id.0.0");
+    println!("  - Retrieved key using: subscription_id.0.0");
+    println!("  - Found {} events", found_events.len());
+}
+
+#[tokio::test]
+async fn test_substrate_key_storage_retrieval_integration() {
+    // Create temporary database with full substrate trees
+    let db = sled::Config::new().temporary(true).open().expect("Failed to open database");
+    let trees = SubstrateTrees::open(&db).expect("Failed to open substrate trees");
+    
+    // Test subscription ID
+    let subscription_id = SubscriptionId::from(hex!("c589244f4d5c8e64c378acde541600e215464ec7292e475225e92b0f32896f1b"));
+    let substrate_key = SubstrateKey::SubscriptionId(subscription_id);
+    
+    let block_number = 98765u32;
+    let event_index = 123u16;
+    
+    // Store the event using the SubstrateKey::write_db_key method
+    substrate_key.write_db_key(&trees, block_number, event_index)
+        .expect("Failed to write database key");
+    
+    // Retrieve events using the fixed logic
+    let retrieved_events = match substrate_key {
+        SubstrateKey::SubscriptionId(ref subscription_id) => {
+            get_events_bytes32(&trees.subscription_id, &subscription_id.0)
+        }
+        _ => panic!("Wrong key type"),
+    };
+    
+    // Verify retrieval works
+    assert_eq!(retrieved_events.len(), 1, "Should find exactly one event");
+    assert_eq!(retrieved_events[0].block_number, block_number);
+    assert_eq!(retrieved_events[0].event_index, event_index);
+    
+    println!("✓ SubstrateKey integration test passed");
+    println!("  - Event stored using SubstrateKey::write_db_key");
+    println!("  - Event retrieved using fixed get_events_bytes32 logic");
+    println!("  - Block number: {}, Event index: {}", block_number, event_index);
+}
+
+/// Test to ensure different subscription IDs don't interfere with each other
+#[tokio::test]
+async fn test_multiple_subscription_ids_no_interference() {
+    let db = sled::Config::new().temporary(true).open().expect("Failed to open database");
+    let trees = SubstrateTrees::open(&db).expect("Failed to open substrate trees");
+    
+    // Two different subscription IDs
+    let sub_id_1 = SubscriptionId::from(hex!("c589244f4d5c8e64c378acde541600e215464ec7292e475225e92b0f32896f1b"));
+    let sub_id_2 = SubscriptionId::from(hex!("1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"));
+    
+    // Store events for both subscription IDs
+    let key_1 = SubstrateKey::SubscriptionId(sub_id_1);
+    let key_2 = SubstrateKey::SubscriptionId(sub_id_2);
+    
+    key_1.write_db_key(&trees, 100, 1).expect("Failed to store key_1");
+    key_1.write_db_key(&trees, 101, 2).expect("Failed to store key_1 again");
+    key_2.write_db_key(&trees, 200, 3).expect("Failed to store key_2");
+    
+    // Retrieve events for first subscription ID
+    let events_1 = get_events_bytes32(&trees.subscription_id, &sub_id_1.0);
+    
+    // Retrieve events for second subscription ID  
+    let events_2 = get_events_bytes32(&trees.subscription_id, &sub_id_2.0);
+    
+    // Verify correct event counts and separation
+    assert_eq!(events_1.len(), 2, "Should find 2 events for subscription ID 1");
+    assert_eq!(events_2.len(), 1, "Should find 1 event for subscription ID 2");
+    
+    // Verify events are correctly associated with their subscription IDs
+    assert!(events_1.iter().any(|e| e.block_number == 100 && e.event_index == 1));
+    assert!(events_1.iter().any(|e| e.block_number == 101 && e.event_index == 2));
+    assert!(events_2.iter().any(|e| e.block_number == 200 && e.event_index == 3));
+    
+    println!("✓ Multiple subscription IDs work correctly");
+    println!("  - Subscription ID 1: {} events", events_1.len());
+    println!("  - Subscription ID 2: {} events", events_2.len());
+}
+
+#[tokio::test]
+async fn test_get_events_with_limit_pagination() {
+    let db = Config::new().temporary(true).open().unwrap();
+    let tree = db.open_tree("variants").unwrap();
+    
+    // Create test events for variant query (pallet_id=41, variant_id=1)
+    let pallet_id = 41u8;
+    let variant_id = 1u8;
+    
+    // Add 150 test events to exceed default limit of 100
+    for i in 0..150 {
+        let key = VariantKey {
+            pallet_index: pallet_id,
+            variant_index: variant_id,
+            block_number: (1000 + i as u32).into(),
+            event_index: ((i % 10) as u16).into(),
+        };
+        let mut buf = vec![0u8; 8]; // pallet(1) + variant(1) + block(4) + event(2) = 8 bytes
+        key.write_to(&mut buf).unwrap();
+        tree.insert(buf, b"event_data").unwrap();
+    }
+    
+    // Test 1: Default limit (100 events)
+    let (events, has_more) = get_events_variant_with_limit(&tree, pallet_id, variant_id, Some(100));
+    assert_eq!(events.len(), 100, "Should return exactly 100 events with default limit");
+    assert!(has_more, "Should indicate more events are available");
+    
+    // Test 2: Custom limit (50 events)
+    let (events, has_more) = get_events_variant_with_limit(&tree, pallet_id, variant_id, Some(50));
+    assert_eq!(events.len(), 50, "Should return exactly 50 events with custom limit");
+    assert!(has_more, "Should indicate more events are available");
+    
+    // Test 3: Unlimited (None limit)
+    let (events, has_more) = get_events_variant_with_limit(&tree, pallet_id, variant_id, None);
+    assert_eq!(events.len(), 150, "Should return all 150 events when unlimited");
+    assert!(!has_more, "Should indicate no more events when unlimited");
+    
+    // Test 4: Limit larger than available events
+    let (events, has_more) = get_events_variant_with_limit(&tree, pallet_id, variant_id, Some(200));
+    assert_eq!(events.len(), 150, "Should return all 150 available events");
+    assert!(!has_more, "Should indicate no more events when limit exceeds available");
+    
+    // Test 5: Verify events are ordered by block number (descending - most recent first)
+    let (events, _) = get_events_variant_with_limit(&tree, pallet_id, variant_id, Some(10));
+    for i in 1..events.len() {
+        assert!(events[i-1].block_number >= events[i].block_number, 
+                "Events should be ordered by block number (descending)");
+    }
+    
+    // Test 6: Zero events case (different variant)
+    let (events, has_more) = get_events_variant_with_limit(&tree, 99, 99, Some(100));
+    assert_eq!(events.len(), 0, "Should return no events for non-existent variant");
+    assert!(!has_more, "Should indicate no more events when no events exist");
+    
+    println!("✅ Pagination tests PASSED!");
+    println!("  - Default limit: 100 events (has_more: true)");
+    println!("  - Custom limit: 50 events (has_more: true)");
+    println!("  - Unlimited: 150 events (has_more: false)");
+    println!("  - Large limit: 150 events (has_more: false)");
+    println!("  - Event ordering: Descending by block number ✓");
+    
+    // Clean up
+    drop(tree);
+    drop(db);
+    tokio::time::sleep(Duration::from_millis(1)).await;
+}
+
+/// End-to-end test showing 0x prefixed subscription ID works through full flow
+#[tokio::test]
+async fn test_subscription_id_end_to_end_with_0x_prefix() {
+    // Create temporary database with full trees (like other tests)
+    let db_config = sled::Config::new().temporary(true);
+    let trees = open_trees::<IdnTestIndexer>(db_config).expect("Failed to open trees");
+    
+    // Parse subscription ID from hex string WITH 0x prefix (like frontend would send)
+    let hex_with_prefix = "0xc589244f4d5c8e64c378acde541600e215464ec7292e475225e92b0f32896f1b";
+    let subscription_id = SubscriptionId::from_str(hex_with_prefix)
+        .expect("Failed to parse subscription ID with 0x prefix");
+    
+    println!("📝 Parsed subscription ID from: {}", hex_with_prefix);
+    
+    // Create substrate key from the parsed subscription ID
+    let substrate_key = SubstrateKey::SubscriptionId(subscription_id);
+    
+    let block_number = 42069u32;
+    let event_index = 420u16;
+    
+    // Step 1: Store the event using the SubstrateKey::write_db_key method
+    substrate_key.write_db_key(&trees.substrate, block_number, event_index)
+        .expect("Failed to write database key");
+    
+    println!("💾 Stored event: block #{}, event index #{}", block_number, event_index);
+    
+    // Step 2: Retrieve events using the subscription ID (this tests the full retrieval flow)
+    let retrieved_events = match substrate_key {
+        SubstrateKey::SubscriptionId(ref subscription_id) => {
+            get_events_bytes32(&trees.substrate.subscription_id, &subscription_id.0)
+        }
+        _ => panic!("Wrong key type"),
+    };
+    
+    // Step 3: Verify retrieval worked correctly
+    assert_eq!(retrieved_events.len(), 1, "Should find exactly one event");
+    assert_eq!(retrieved_events[0].block_number, block_number);
+    assert_eq!(retrieved_events[0].event_index, event_index);
+    
+    // Step 4: Also test via the process_msg_get_events_substrate function 
+    // (this simulates the actual WebSocket API call)
+    let api_retrieved_events = process_msg_get_events_substrate::<IdnTestIndexer>(
+        &trees,
+        &SubstrateKey::SubscriptionId(subscription_id),
+    );
+    
+    assert_eq!(api_retrieved_events.len(), 1, "API should find exactly one event");
+    assert_eq!(api_retrieved_events[0].block_number, block_number);
+    assert_eq!(api_retrieved_events[0].event_index, event_index);
+    
+    // Step 5: Verify that the same subscription ID parsed without 0x prefix 
+    // would retrieve the same events (consistency check)
+    let hex_without_prefix = "c589244f4d5c8e64c378acde541600e215464ec7292e475225e92b0f32896f1b";
+    let subscription_id_no_prefix = SubscriptionId::from_str(hex_without_prefix)
+        .expect("Failed to parse subscription ID without 0x prefix");
+    
+    // They should be identical
+    assert_eq!(subscription_id, subscription_id_no_prefix);
+    
+    // And should retrieve the same events
+    let events_no_prefix = get_events_bytes32(&trees.substrate.subscription_id, &subscription_id_no_prefix.0);
+    assert_eq!(events_no_prefix.len(), 1);
+    assert_eq!(events_no_prefix[0].block_number, block_number);
+    assert_eq!(events_no_prefix[0].event_index, event_index);
+    
+    println!("✅ End-to-end test PASSED with 0x prefix!");
+    println!("  - Parsed: {}", hex_with_prefix);
+    println!("  - Stored: 1 event at block {} index {}", block_number, event_index);
+    println!("  - Retrieved: {} events via direct query", retrieved_events.len());
+    println!("  - Retrieved: {} events via API simulation", api_retrieved_events.len());
+    println!("  - Consistency: 0x and non-0x formats are identical ✓");
+}
+
+
+
+#[tokio::test]
+async fn test_subscription_id_pagination() {
+    let db = Config::new().temporary(true).open().unwrap();
+    let tree = db.open_tree("subscription_id").unwrap();
+    
+    let subscription_id = SubscriptionId(Bytes32::from_str("c589244f4d5c8e64c378acde541600e215464ec7292e475225e92b0f32896f1b").unwrap());
+    
+    // Add 120 events for this subscription ID
+    for i in 0..120 {
+        let key = Bytes32Key {
+            key: subscription_id.0.0,
+            block_number: (2000 + i as u32).into(),
+            event_index: ((i % 5) as u16).into(),
+        };
+        let mut buf = vec![0u8; 38]; // key(32) + block(4) + event(2) = 38 bytes
+        key.write_to(&mut buf).unwrap();
+        tree.insert(buf, b"sub_event_data").unwrap();
+    }
+    
+    // Test with different limits
+    let (events, has_more) = get_events_bytes32_with_limit(&tree, &subscription_id.0, Some(50));
+    assert_eq!(events.len(), 50, "Should return 50 events for subscription ID");
+    assert!(has_more, "Should indicate more events available for subscription ID");
+    
+    let (events, has_more) = get_events_bytes32_with_limit(&tree, &subscription_id.0, None);
+    assert_eq!(events.len(), 120, "Should return all 120 events for subscription ID when unlimited");
+    assert!(!has_more, "Should indicate no more events when unlimited");
+    
+    println!("✅ Subscription ID pagination tests PASSED!");
+    println!("  - Limited: 50 events (has_more: true)");
+    println!("  - Unlimited: 120 events (has_more: false)");
+    
+    // Clean up
+    drop(tree);
+    drop(db);
+    tokio::time::sleep(Duration::from_millis(1)).await;
+}
+
+
+
+#[tokio::test]
+async fn test_websocket_message_get_events_with_limit() {
+    use crate::websockets::process_msg_get_events_with_limit;
+    use crate::shared::{Key, ResponseMessage};
+    
+    let db_config = Config::new().temporary(true);
+    let trees = open_trees::<IdnTestIndexer>(db_config).unwrap();
+    
+    // Add test events
+    let pallet_id = 41u8;
+    let variant_id = 1u8;
+    for i in 0..80 {
+        let key = VariantKey {
+            pallet_index: pallet_id,
+            variant_index: variant_id,
+            block_number: (5000 + i as u32).into(),
+            event_index: (i as u16).into(),
+        };
+        let mut buf = vec![0u8; 8]; // pallet(1) + variant(1) + block(4) + event(2) = 8 bytes
+        key.write_to(&mut buf).unwrap();
+        trees.variant.insert(buf, b"msg_test_data").unwrap();
+    }
+    
+    // Test GetEventsWithLimit message processing
+    let response = process_msg_get_events_with_limit::<IdnTestIndexer>(
+        &trees,
+        Key::Variant(pallet_id, variant_id),
+        Some(30),
+    );
+    
+    match response {
+        ResponseMessage::EventsWithLimit { key, events, has_more, total_returned } => {
+            assert_eq!(total_returned, 30, "Should return metadata indicating 30 events");
+            assert_eq!(events.len(), 30, "Should return exactly 30 events");
+            assert!(has_more, "Should indicate more events are available");
+            
+            match key {
+                Key::Variant(p, v) => {
+                    assert_eq!(p, pallet_id, "Pallet ID should match");
+                    assert_eq!(v, variant_id, "Variant ID should match");
+                }
+                _ => panic!("Key should be Variant type"),
+            }
+        }
+        _ => panic!("Should return EventsWithLimit response"),
+    }
+    
+    // Test unlimited query
+    let response = process_msg_get_events_with_limit::<IdnTestIndexer>(
+        &trees,
+        Key::Variant(pallet_id, variant_id),
+        None,
+    );
+    
+    match response {
+        ResponseMessage::EventsWithLimit { events, has_more, total_returned, .. } => {
+            assert_eq!(total_returned, 80, "Should return metadata indicating 80 events");
+            assert_eq!(events.len(), 80, "Should return all 80 events");
+            assert!(!has_more, "Should indicate no more events when unlimited");
+        }
+        _ => panic!("Should return EventsWithLimit response"),
+    }
+    
+    println!("✅ WebSocket message pagination tests PASSED!");
+    println!("  - Limited request: 30 events (has_more: true)");
+    println!("  - Unlimited request: 80 events (has_more: false)");
+    println!("  - Response format: EventsWithLimit ✓");
+    
+    // Clean up
+    drop(trees);
+    tokio::time::sleep(Duration::from_millis(1)).await;
 }


### PR DESCRIPTION
Add Comprehensive Pagination Support for Event Queries and Fix Subscription ID Handling

## 📋 Overview

This PR implements comprehensive pagination support for event queries in the Substrate indexer, removing the previous 100-event limitation and enabling retrieval of complete event histories. Additionally, it fixes subscription ID handling to support hex strings with or without the [0x](cci:1://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/tests/idn.rs:768:0-839:1) prefix.

## 🚀 Features Added

### 1. **Pagination Support for Event Queries**
- **New Message Types:**
  - `RequestMessage::GetEventsWithLimit { key, limit }` - Accepts optional limit parameter
  - `ResponseMessage::EventsWithLimit { key, events, has_more, total_returned }` - Returns pagination metadata

- **Enhanced Core Functions:**
  - [get_events_variant_with_limit()](cci:1://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/websockets.rs:79:0-103:1) - Variant events with optional limit
  - [get_events_bytes32_with_limit()](cci:1://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/websockets.rs:109:0-133:1) - Bytes32 key events with optional limit  
  - [get_events_u32_with_limit()](cci:1://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/websockets.rs:139:0-163:1) - U32 key events with optional limit
  - All functions now return [(Vec<Event>, bool)](cci:1://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/tests/idn.rs:42:4-48:5) tuples indicating events and if more exist

- **WebSocket API Integration:**
  - [process_msg_get_events_with_limit()](cci:1://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/websockets.rs:232:0-258:1) - New processing function for paginated requests
  - Full integration with existing WebSocket message handling pipeline
  - Support for both limited and unlimited event queries

### 2. **Subscription ID Handling Fixes**
- Enhanced `Bytes32::from_str()` to handle hex strings with or without [0x](cci:1://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/tests/idn.rs:768:0-839:1) prefix
- Fixed subscription ID event retrieval key consistency
- Improved error handling for subscription ID parsing and storage
- Robust handling of different hex string formats from frontend clients

### 3. **Backward Compatibility**
- All existing `GetEvents` requests continue working unchanged
- Default 100-event limit maintained for non-paginated queries
- No breaking changes to existing API contracts

## 🔧 Technical Changes

### Files Modified:
- **[src/shared.rs](cci:7://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/shared.rs:0:0-0:0)** - Added new request/response message types
- **[src/websockets.rs](cci:7://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/websockets.rs:0:0-0:0)** - Enhanced event retrieval functions with pagination support
- **[src/tests/idn.rs](cci:7://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/tests/idn.rs:0:0-0:0)** - Comprehensive test coverage (+432 lines)

### Key Implementation Details:
- **Limit Handling:** `limit: None` = unlimited, `limit: Some(n)` = max n events
- **Event Ordering:** Maintained descending order by block number (most recent first)
- **Pagination Metadata:** `has_more` flag indicates if additional events exist
- **Performance:** Efficient prefix scanning with early termination when limit reached

## 🧪 Testing

Added comprehensive test coverage with **16 tests passing**:

### Core Pagination Tests:
- ✅ [test_get_events_with_limit_pagination](cci:1://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/tests/idn.rs:701:0-766:1) - Default, custom, unlimited, and oversized limits
- ✅ [test_subscription_id_pagination](cci:1://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/tests/idn.rs:843:0-879:1) - Subscription ID events with limit support
- ✅ [test_websocket_message_get_events_with_limit](cci:1://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/tests/idn.rs:903:0-976:1) - WebSocket API pagination

### Subscription ID Integration Tests:
- ✅ [test_subscription_id_key_consistency](cci:1://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/tests/idn.rs:543:0-555:1) - Hex parsing without 0x prefix
- ✅ [test_subscription_id_key_consistency_with_0x_prefix](cci:1://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/tests/idn.rs:557:0-574:1) - Hex parsing with 0x prefix
- ✅ [test_subscription_id_database_storage_retrieval](cci:1://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/tests/idn.rs:576:0-625:1) - Database consistency
- ✅ [test_substrate_key_storage_retrieval_integration](cci:1://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/tests/idn.rs:627:0-661:1) - Full SubstrateKey integration
- ✅ [test_multiple_subscription_ids_no_interference](cci:1://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/tests/idn.rs:663:0-699:1) - Multiple subscription ID isolation
- ✅ [test_subscription_id_end_to_end_with_0x_prefix](cci:1://file:///Users/carloskiron/Documents/Code/Ideal/idn-acuity-index-substrate/src/tests/idn.rs:768:0-839:1) - Complete end-to-end flow

## 📖 Usage Examples

### Get Unlimited Events
```json
{
  "type": "GetEventsWithLimit",
  "key": { "type": "Variant", "value": [41, 1] },
  "limit": null
}

{
  "type": "GetEventsWithLimit", 
  "key": { 
    "type": "Substrate", 
    "value": { 
      "type": "SubscriptionId", 
      "value": "0xc589244f4d5c8e64c378acde541600e215464ec7292e475225e92b0f32896f1b" 
    } 
  },
  "limit": 500
}

{
  "type": "eventsWithLimit",
  "data": {
    "key": { "type": "Variant", "value": [41, 1] },
    "events": [
      { "block_number": 12345, "event_index": 1 },
      { "block_number": 12344, "event_index": 2 }
    ],
    "hasMore": false,
    "totalReturned": 1247
  }
}